### PR TITLE
Add double-quotes to Digraph ID parameter

### DIFF
--- a/functions.inc.php
+++ b/functions.inc.php
@@ -72,7 +72,7 @@ function dp_follow_destinations (&$route, $destination) {
 	global $direction;
 
   if (! isset ($route['dpgraph'])) {
-    $route['dpgraph'] = new Alom\Graphviz\Digraph($route['extension']);
+    $route['dpgraph'] = new Alom\Graphviz\Digraph('"'.$route['extension'].'"');
 		$route['dpgraph']->attr('graph',array('rankdir'=>$direction));
   }
   $dpgraph = $route['dpgraph'];


### PR DESCRIPTION
Routes with the DID in E.164 format (+1NPANXXXXXX, etc.) do not render properly due to the DID being directly used as an ID parameter without any kind of escaping, resulting in a Javascript syntax error when it hits the plus sign while trying to render.

This just wraps that parameter in double quotes which seems to solve the error and I haven't noticed anything breaking as a result.  It still works fine with non-E.164 routes.